### PR TITLE
fix: hadolint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM bash:5.3.8-alpine3.22 AS builder
 
+WORKDIR /
+
 COPY . .
-RUN ./bin/redirects.sh
-RUN wget https://www.jenkins.io/favicon.ico
+RUN ./bin/redirects.sh \
+    && wget --quiet https://www.jenkins.io/favicon.ico
 
 FROM nginx:1.29.3-alpine
 


### PR DESCRIPTION
This PR fixes hadolint.

```
Dockerfile:3 DL3045 warning: `COPY` to a relative destination without `WORKDIR` set.
Dockerfile:5 DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`. Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
Dockerfile:5 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
```

#### Testing done
`hadolint Dockerfile`