### PR TITLE
feat: add `/browse/:jira_key` redirections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A default rule will redirect any unknown issue IDs to Jira.
 
 ## API
 
-- `GET /:jira_key` - Redirects to the corresponding GitHub issue, if found. Otherwise to Jira.
+- `GET /browse/:jira_key` - Redirects to the corresponding GitHub issue, if found. Otherwise to Jira.
+- `GET /:jira_key` - Redirects to the corresponding GitHub issue, if found. Otherwise to Jira. (Kept for compatibility with existing uses)
 - `GET /issue/:jira_key_id` - Redirects to the corresponding GitHub issue, if found. Otherwise to Jira prefixing it with `JENKINS-`. (Kept for compatibility with existing uses)
 
 Ex:

--- a/bin/redirects.sh
+++ b/bin/redirects.sh
@@ -22,6 +22,7 @@ while IFS=: read -r jira_key github_ref; do
 
       echo "rewrite ^/issue/$issue_num$ https://github.com/$repo_path/issues/$github_issue permanent;" >> "$REDIRECTS_FILE"
       echo "rewrite ^/JENKINS-$issue_num$ https://github.com/$repo_path/issues/$github_issue permanent;" >> "$REDIRECTS_FILE"
+      echo "rewrite ^/browse/JENKINS-$issue_num$ https://github.com/$repo_path/issues/$github_issue permanent;" >> "$REDIRECTS_FILE"
     fi
   fi
   # INFRA project
@@ -34,6 +35,7 @@ while IFS=: read -r jira_key github_ref; do
       github_issue="${BASH_REMATCH[2]}"
 
       echo "rewrite ^/INFRA-$issue_num$ https://github.com/$repo_path/issues/$github_issue permanent;" >> "$REDIRECTS_FILE"
+      echo "rewrite ^/browse/INFRA-$issue_num$ https://github.com/$repo_path/issues/$github_issue permanent;" >> "$REDIRECTS_FILE"
     fi
   fi
 done < "$MAPPINGS_FILE"

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -5,6 +5,8 @@ server {
   root   /htdocs;
 
   include includes/jira-to-github-redirects.conf;
-  rewrite ^/issue/(.+)          https://issues.jenkins.io/browse/JENKINS-$1 permanent;
-  rewrite ^/JENKINS-(.+)                https://issues.jenkins.io/browse/JENKINS-$1 permanent;
+  rewrite ^/issue/(.+)            https://issues.jenkins.io/browse/JENKINS-$1 permanent;
+  rewrite ^/JENKINS-(.+)          https://issues.jenkins.io/browse/JENKINS-$1 permanent;
+  rewrite ^/browse/JENKINS-(.+)   https://issues.jenkins.io/browse/JENKINS-$1 permanent;
+  rewrite ^/browse/INFRA-(.+)     https://issues.jenkins.io/browse/INFRA-$1 permanent;
 }

--- a/docker/index.html
+++ b/docker/index.html
@@ -14,9 +14,12 @@
 
             <p>API:</p>
             <ul>
+                <li><code>GET /browse/:jira_key</code> - Redirects to the corresponding GitHub issue, if found. Otherwise to Jira.</li>
                 <li><code>GET /:jira_key</code> - Redirects to the corresponding GitHub issue, if found. Otherwise to Jira.</li>
                 <li><code>GET /issue/:jira_key_id</code> - Redirects to the corresponding GitHub issue, if found. Otherwise to Jira prefixing it with JENKINS-.</li>
             </ul>
+
+            <p>Example of usage: replace the <code>issues</code> subdomain of any Jira link like https://issues.jenkins.io/browse/JENKINS-1 by <code>issue-redirect</code>: https://issue-redirect.jenkins.io/browse/JENKINS-1</p>
 
             <p>To add more Jira redirects send a pull request to <a href="https://github.com/jenkins-infra/docker-issue-redirect/blob/main/mappings/jira_keys_to_github_ids.txt">jira_keys_to_github_ids.txt</a>.</p>
         </main>


### PR DESCRIPTION
This PR adds those redirections so getting a redirect link from a Jira one is as simple as replacing `issues` subdomain by `issue-redirect`:

```diff
- https://issues.jenkins.io/browse/JENKINS-1
+ https://issue-redirect.jenkins.io/browse/JENKINS-1
```

It also add the missing INFRA redirection fallback in case there is no mapping corresponding to the INFRA Jira key (should not happens as all INFRA issues have been migrated, more here for consistency).

Amends:
- #7
- #8 

Ref:
- #6 (the given example was wrong/incomplete)

#### Testing done
`docker compose up` then checked that localhost:8060/browse/JENKINS-70000 redirects to issues.jenkins.io/browse/JENKINS-70000