### PR TITLE
fix: proper `server_name`

### DIFF
--- a/docker/default.conf
+++ b/docker/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  server_name _ localhost;
+  server_name _ localhost issue-redirect.jenkins.io;
 
   root /htdocs;
 


### PR DESCRIPTION
This PR should fix the remaining redirections errors.

Follow-up of:
- #12 

Ref:
- https://github.com/jenkins-infra/docker-issue-redirect/issues/11#issuecomment-3683233181