### PR TITLE
fix: use `location` instead of `rewrite` directive to avoid rewrite loop

### DIFF
--- a/docker/default.conf
+++ b/docker/default.conf
@@ -4,14 +4,32 @@ server {
 
   root /htdocs;
 
+  # Serve index.html
+  location = / {
+    try_files /index.html =404;
+  }
+
   # Exact generated redirects
   include includes/jira-to-github-redirects.conf;
 
   # Generic fallback rewrites
-  rewrite ^/issue/([0-9]+)$ https://issues.jenkins.io/browse/JENKINS-$1 permanent;
-  rewrite ^/issue/([A-Z]+-[0-9]+)$ https://issues.jenkins.io/browse/$1 permanent;
-  rewrite ^/([A-Z]+-[0-9]+)$ https://issues.jenkins.io/browse/$1 permanent;
-  rewrite ^/browse/([A-Z]+-[0-9]+)$ https://issues.jenkins.io/browse/$1 permanent;
+  # /issue/12345
+  location ~ ^/issue/([0-9]+)$ {
+    return 301 https://issues.jenkins.io/browse/JENKINS-$1;
+  }
 
-  return 404;
+  # /issue/JENKINS-12345 or /issue/INFRA-123
+  location ~ ^/issue/([A-Z]+-[0-9]+)$ {
+    return 301 https://issues.jenkins.io/browse/$1;
+  }
+
+  # /JENKINS-12345 or /INFRA-123
+  location ~ ^/([A-Z]+-[0-9]+)$ {
+    return 301 https://issues.jenkins.io/browse/$1;
+  }
+
+  # /browse/JENKINS-12345 or /browse/INFRA-123
+  location ~ ^/browse/([A-Z]+-[0-9]+)$ {
+    return 301 https://issues.jenkins.io/browse/$1;
+  }
 }


### PR DESCRIPTION
This PR uses `location` instead of `rewrite` directive to avoid rewrite loop making https://issue-redirect.jenkins.io/issue/JENKINS-10000 redirects to https://issues.jenkins.io/browse/JENKINS-JENKINS-10000, and https://issue-redirect.jenkins.io/JENKINS-10000 & https://issue-redirect.jenkins.io/browse/JENKINS-10000 returning a 404 error.

Ref:
- https://github.com/jenkins-infra/docker-issue-redirect/issues/11#issuecomment-3683233181

#### Testing done

Same `localhost` tests as in #12

<details><summary>Additional `curl` tests on those 3 remaining redirections errors:</summary>

```bash
$ curl -v -H "Host: issue-redirect.jenkins.io" http://127.0.0.1:8060/issue/JENKINS-10000 
*   Trying 127.0.0.1:8060...
* Connected to 127.0.0.1 (127.0.0.1) port 8060
> GET /issue/JENKINS-10000 HTTP/1.1
> Host: issue-redirect.jenkins.io
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.29.3
< Date: Thu, 25 Dec 2025 20:22:39 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: keep-alive
< Location: https://issues.jenkins.io/browse/JENKINS-10000
< 
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.29.3</center>
</body>
</html>
* Connection #0 to host 127.0.0.1 left intact

$ curl -v -H "Host: issue-redirect.jenkins.io" http://127.0.0.1:8060/JENKINS-10000 
*   Trying 127.0.0.1:8060...
* Connected to 127.0.0.1 (127.0.0.1) port 8060
> GET /JENKINS-10000 HTTP/1.1
> Host: issue-redirect.jenkins.io
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.29.3
< Date: Thu, 25 Dec 2025 20:23:17 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: keep-alive
< Location: https://issues.jenkins.io/browse/JENKINS-10000
< 
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.29.3</center>
</body>
</html>
* Connection #0 to host 127.0.0.1 left intact

$ curl -v -H "Host: issue-redirect.jenkins.io" http://127.0.0.1:8060/browse/JENKINS-10000
*   Trying 127.0.0.1:8060...
* Connected to 127.0.0.1 (127.0.0.1) port 8060
> GET /browse/JENKINS-10000 HTTP/1.1
> Host: issue-redirect.jenkins.io
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.29.3
< Date: Thu, 25 Dec 2025 20:23:34 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: keep-alive
< Location: https://issues.jenkins.io/browse/JENKINS-10000
< 
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.29.3</center>
</body>
</html>
* Connection #0 to host 127.0.0.1 left intact
```

</details>

<details><summary>FWIW</summary>

I tried to test locally on my mac with final domain by adding the following to my /etc/host:
```
127.0.0.1 issue-redirect.jenkins.io
```
Then
```
sudo dscacheutil -flushcache
sudo killall -HUP mDNSResponder
```
But didn't succeed to see my change in a new browser instance.

</details>