### PR TITLE
Use 'with: token' instead of 'env: GITHUB_TOKEN' in release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,5 +25,4 @@ jobs:
           name: next
           tag: next
           version: next
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Release drafter 7.0.0 uses `with: token` instead of `env: GITHUB_TOKEN`

The [https://github.com/release-drafter/release-drafter/pull/1475](breaking changes section) for release drafter 7.0.0 says:

> If you were using a specific access token using env.GITHUB_TOKEN: $MY_CUSTOM_TOKEN, migrate to the new token: 
>
> ```
> jobs:
>   steps:
>     # Before
>     - uses: release-drafter/release-drafter@v6
>       env:
>         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
>     # After
>     - uses: release-drafter/release-drafter@v7
>       with:
>         token: ${{ secrets.GITHUB_TOKEN }}
> ```